### PR TITLE
ruff check --fix

### DIFF
--- a/src/expidite_etl/utils.py
+++ b/src/expidite_etl/utils.py
@@ -1,6 +1,7 @@
 import shutil
 
 import pandas as pd
+
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.core import file_naming
 from expidite_rpi.core.cloud_connector import CloudConnector

--- a/src/expidite_rpi/sensors/processor_video_aruco.py
+++ b/src/expidite_rpi/sensors/processor_video_aruco.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import cv2
 import numpy as np
 import pandas as pd
+
 from expidite_rpi.core import api, file_naming
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.core.dp import DataProcessor

--- a/src/expidite_rpi/sensors/processor_video_trapcam.py
+++ b/src/expidite_rpi/sensors/processor_video_trapcam.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import cv2
 import pandas as pd
+
 from expidite_rpi.core import api, file_naming
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.core.dp import DataProcessor

--- a/src/expidite_rpi/sensors/sensor_adxl34x.py
+++ b/src/expidite_rpi/sensors/sensor_adxl34x.py
@@ -5,6 +5,7 @@ import time
 from dataclasses import dataclass
 
 import pandas as pd
+
 from expidite_rpi.core import api
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.core.dp_config_objects import Stream

--- a/src/expidite_rpi/sensors/sensor_bmp280.py
+++ b/src/expidite_rpi/sensors/sensor_bmp280.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 import adafruit_bmp280
+
 from expidite_rpi.core import api
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.core.dp_config_objects import Stream

--- a/src/expidite_rpi/sensors/sensor_ltr390.py
+++ b/src/expidite_rpi/sensors/sensor_ltr390.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 
 import adafruit_ltr390
+
 from expidite_rpi.core import api
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.core.dp_config_objects import Stream

--- a/src/expidite_rpi/sensors/sensor_sht40.py
+++ b/src/expidite_rpi/sensors/sensor_sht40.py
@@ -1,13 +1,14 @@
 from dataclasses import dataclass
 from time import sleep
 
+from sensirion_driver_adapters.i2c_adapter.i2c_channel import I2cChannel
+from sensirion_i2c_driver import CrcCalculator, I2cConnection, LinuxI2cTransceiver
+from sensirion_i2c_sht4x.device import Sht4xDevice
+
 from expidite_rpi.core import api
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.core.dp_config_objects import Stream
 from expidite_rpi.core.sensor import Sensor, SensorCfg
-from sensirion_driver_adapters.i2c_adapter.i2c_channel import I2cChannel
-from sensirion_i2c_driver import CrcCalculator, I2cConnection, LinuxI2cTransceiver
-from sensirion_i2c_sht4x.device import Sht4xDevice
 
 logger = root_cfg.setup_logger("expidite")
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,7 @@
 import time
 
 import pytest
+
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.core.cloud_connector import CloudConnector
 

--- a/test/rpi_core/core/cloud_connector_test.py
+++ b/test/rpi_core/core/cloud_connector_test.py
@@ -2,6 +2,7 @@ import logging
 from time import sleep
 
 import pandas as pd
+
 from expidite_rpi.core import api, file_naming
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.core.cloud_connector import AsyncCloudConnector, CloudConnector, LocalCloudConnector

--- a/test/rpi_core/core/cloud_journal_test.py
+++ b/test/rpi_core/core/cloud_journal_test.py
@@ -2,6 +2,7 @@
 from time import sleep
 
 import pytest
+
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.core.cloud_connector import AsyncCloudConnector, CloudConnector
 from expidite_rpi.utils.cloud_journal import CloudJournal

--- a/test/rpi_core/core/configuration_test.py
+++ b/test/rpi_core/core/configuration_test.py
@@ -1,5 +1,6 @@
 
 import pytest
+
 from expidite_rpi.core import config_validator
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.example import my_fleet_config

--- a/test/rpi_core/core/device_manager_test.py
+++ b/test/rpi_core/core/device_manager_test.py
@@ -1,4 +1,5 @@
 import pytest
+
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.core import device_manager
 

--- a/test/rpi_core/core/file_naming_test.py
+++ b/test/rpi_core/core/file_naming_test.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 import pytest
+
 from expidite_rpi.core import api, file_naming
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.core.dp_tree import DPtree

--- a/test/rpi_core/core/journal_test.py
+++ b/test/rpi_core/core/journal_test.py
@@ -2,6 +2,7 @@ import os
 
 import pandas as pd
 import pytest
+
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.utils.journal import Journal
 

--- a/test/rpi_core/core/orchetstrator_test.py
+++ b/test/rpi_core/core/orchetstrator_test.py
@@ -3,6 +3,7 @@ from threading import Thread
 from time import sleep
 
 import pytest
+
 from expidite_rpi.core import api, edge_orchestrator
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.core.edge_orchestrator import EdgeOrchestrator

--- a/test/rpi_core/core/rpi_core_test.py
+++ b/test/rpi_core/core/rpi_core_test.py
@@ -2,6 +2,7 @@ from time import sleep
 
 import pytest
 import pytest_socket
+
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.example import my_fleet_config
 from expidite_rpi.rpi_core import RpiCore

--- a/test/rpi_core/core/rpi_emulator_test.py
+++ b/test/rpi_core/core/rpi_emulator_test.py
@@ -1,6 +1,7 @@
 import logging
 
 import pytest
+
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.utils import rpi_emulator
 

--- a/test/rpi_core/core/utils_test.py
+++ b/test/rpi_core/core/utils_test.py
@@ -2,6 +2,7 @@ import datetime as dt
 from datetime import datetime
 
 import pytest
+
 from expidite_rpi.core import api
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.utils import utils

--- a/test/rpi_core/sensors/adxl34x_device_test.py
+++ b/test/rpi_core/sensors/adxl34x_device_test.py
@@ -1,6 +1,7 @@
 from time import sleep
 
 import pytest
+
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.core.device_config_objects import DeviceCfg
 from expidite_rpi.rpi_core import RpiCore

--- a/test/rpi_core/sensors/bmp280_device_test.py
+++ b/test/rpi_core/sensors/bmp280_device_test.py
@@ -1,6 +1,7 @@
 from time import sleep
 
 import pytest
+
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.core.device_config_objects import DeviceCfg
 from expidite_rpi.rpi_core import RpiCore

--- a/test/rpi_core/sensors/example_device_test.py
+++ b/test/rpi_core/sensors/example_device_test.py
@@ -2,6 +2,7 @@ import logging
 from time import sleep
 
 import pytest
+
 from expidite_rpi.core import api
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.core.device_config_objects import DeviceCfg

--- a/test/rpi_core/sensors/processor_video_aruco_test.py
+++ b/test/rpi_core/sensors/processor_video_aruco_test.py
@@ -2,6 +2,7 @@ import logging
 import sys
 
 import pytest
+
 from expidite_rpi.core import configuration as root_cfg
 
 logger = root_cfg.setup_logger("expidite")

--- a/test/rpi_core/sensors/sht31_device_test.py
+++ b/test/rpi_core/sensors/sht31_device_test.py
@@ -1,6 +1,7 @@
 from time import sleep
 
 import pytest
+
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.core.device_config_objects import DeviceCfg
 from expidite_rpi.rpi_core import RpiCore

--- a/test/rpi_core/sensors/sht40_device_test.py
+++ b/test/rpi_core/sensors/sht40_device_test.py
@@ -1,6 +1,7 @@
 from time import sleep
 
 import pytest
+
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.core.device_config_objects import DeviceCfg
 from expidite_rpi.rpi_core import RpiCore

--- a/test/rpi_core/sensors/trap_cam_device_test.py
+++ b/test/rpi_core/sensors/trap_cam_device_test.py
@@ -1,6 +1,7 @@
 from time import sleep
 
 import pytest
+
 from expidite_rpi.core import configuration as root_cfg
 from expidite_rpi.core.device_config_objects import DeviceCfg
 from expidite_rpi.rpi_core import RpiCore


### PR DESCRIPTION
There were some existing ruff errors in the codebase. Get these out of the way before working on anything else. 

All fixed made automatically with `ruff check --fix`. All changes are to import ordering/spacing.