### PR TITLE
Remove references to Bee Ops

### DIFF
--- a/src/expidite_rpi/core/api.py
+++ b/src/expidite_rpi/core/api.py
@@ -1,7 +1,7 @@
 ####################################################################################################
-# Bee Ops API
+# Expidite API
 #
-# File define constants used on interfaces between components in the Bee Ops system.
+# File define constants used on interfaces between components in the Expidite system.
 ####################################################################################################
 from datetime import datetime
 from enum import Enum, StrEnum

--- a/src/expidite_rpi/core/configuration.py
+++ b/src/expidite_rpi/core/configuration.py
@@ -219,10 +219,10 @@ ST_MODE: SOFTWARE_TEST_MODE = SOFTWARE_TEST_MODE.LIVE
 # Set up logging
 #
 # The logging level is a combination of:
-#  - the value set in bee-ops.cfg
+#  - the value set in config
 #  - the value requested by the calling module (default is INFO)
 #
-# There is update code at the end of this file that sets the level once we've loaded bee-ops.cfg
+# There is update code at the end of this file that sets the level once we've loaded config.
 ############################################################################################################
 TEST_LOG = LOG_DIR.joinpath("test.log")
 _DEFAULT_LOG: Optional[Path] = None

--- a/src/expidite_rpi/core/device_manager.py
+++ b/src/expidite_rpi/core/device_manager.py
@@ -309,7 +309,6 @@ class DeviceManager:
                         utils.run_cmd("sudo nmcli general reload", ignore_errors=True)
 
                     elif self.ping_failure_count_run % retry_frequency == 240:
-                        # Explicitly connect to bee-ops wifi network
                         logger.info("Explicitly connecting to wifi network")
                         for client in self.wifi_clients:
                             if client.ssid is not None and client.pw is not None:

--- a/src/expidite_rpi/scripts/rpi_installer.sh
+++ b/src/expidite_rpi/scripts/rpi_installer.sh
@@ -609,8 +609,8 @@ set_log_storage_volatile() {
 ###############################################
 # Create RAM disk
 #
-# If we're running off an SD card, we use a ramdisk instead of the SD card for the /bee-ops directory.
-# If we're running off an SSD, we mount /bee-ops on the SSD.
+# If we're running off an SD card, we use a ramdisk instead of the SD card for the /expidite directory.
+# If we're running off an SSD, we mount /expidite on the SSD.
 ###############################################
 create_mount() {
     mountpoint="/expidite"
@@ -628,7 +628,7 @@ create_mount() {
     else
         echo "Running on SD card. Mount the RAM disk."
         # All rpi_sensors have a minimum RAM of 4GB, so /dev/shm/ defaults to 2GB
-        # We reduce this to 500M for rpi_sensor installations and assign 1.5GB to /bee-ops
+        # We reduce this to 500M for rpi_sensor installations and assign 1.5GB to /expidite
         mount_size="1200M"
         if grep -Eqs "$mountpoint.*$mount_size" /etc/fstab; then
             echo "The mount point already exists in fstab with the correct size."

--- a/test/rpi_core/core/orchetstrator_test.py
+++ b/test/rpi_core/core/orchetstrator_test.py
@@ -29,7 +29,7 @@ class Test_Orchestrator:
     def test_Orchestrator(self) -> None:
         logger.info("Run test_Orchestrator test")
         # We reset cfg.my_device_id to override the computers mac_address
-        # This is a test device defined in BeeOps.cfg to have a DummySensor.
+        # This is a test device defined to have a DummySensor.
         root_cfg.update_my_device_id("d01111111111")
 
         with rpi_emulator.RpiEmulator.get_instance() as th:
@@ -74,7 +74,7 @@ class Test_Orchestrator:
 
     def test_orchestrator_main(self) -> None:
         # We reset cfg.my_device_id to override the computers mac_address
-        # This is a test device defined in BeeOps.cfg to have a DummySensor.
+        # This is a test device defined to have a DummySensor.
         logger.info("Run test_orchestrator_main test")
         root_cfg.update_my_device_id("d01111111111")
         

--- a/test/rpi_core/core/rpi_core_test.py
+++ b/test/rpi_core/core/rpi_core_test.py
@@ -24,7 +24,7 @@ class Test_SensorFactory:
         logger.info("Run test_RpiCore_cycle test")
         # Standard flow
         # We reset cfg.my_device_id to override the computers mac_address
-        # This is a test device defined in BeeOps.cfg to have a DummySensor.
+        # This is a test device defined to have a DummySensor.
         with RpiEmulator.get_instance() as th:
             # Mock the timers in the inventory for faster testing
             inventory = th.mock_timers(my_fleet_config.INVENTORY)


### PR DESCRIPTION
Expidite should only reference anything "Bee Ops" for the name of the GitHub organisation. Remove obsolete / incorrect references.

Expidite does still depend on an OS user called `bee-ops` (see led-manager.service). Save fixing that for another day.