### PR TITLE
Remove swap memory and lower memory use threshold for reboot

### DIFF
--- a/src/expidite_rpi/core/device_health.py
+++ b/src/expidite_rpi/core/device_health.py
@@ -309,8 +309,11 @@ class DeviceHealth(Sensor):
             if memory_usage > 75:
                 if root_cfg.running_on_rpi:
                     DeviceHealth.log_top_memory_processes()
-                    if memory_usage > 95:
-                        logger.error(root_cfg.RAISE_WARN() + "Memory usage >95%, rebooting")
+                    # Running low on free RAM can cause any OS process to be killed to free up memory, and can
+                    # cause performance degradation. Triggering a controlled reboot at 90% memory usage is
+                    # generally considered good practice to recover before performance degrades.
+                    if memory_usage > 90:
+                        logger.error(root_cfg.RAISE_WARN() + "Memory usage >90%, rebooting")
                         utils.run_cmd("sudo reboot", ignore_errors=True)
 
             # Get the expidite version and user code version from the files

--- a/src/expidite_rpi/core/device_health.py
+++ b/src/expidite_rpi/core/device_health.py
@@ -304,7 +304,7 @@ class DeviceHealth(Sensor):
             total_memory = psutil.virtual_memory().total
             total_memory_gb = round(total_memory / (1024**3), 2)
 
-            # Memory usage - if greater than 60% then generate some diagnostics
+            # Memory usage - if greater than 75% then generate some diagnostics
             memory_usage = psutil.virtual_memory().percent
             if memory_usage > 75:
                 if root_cfg.running_on_rpi:

--- a/src/expidite_rpi/scripts/rpi_installer.sh
+++ b/src/expidite_rpi/scripts/rpi_installer.sh
@@ -657,6 +657,7 @@ create_mount() {
         # frequent disk writes.
         sudo systemctl disable dphys-swapfile
         sudo systemctl stop dphys-swapfile
+        # Remove the (now unnecessary) swapfile, if it exists.
         sudo rm /var/swap 2>/dev/null
     fi
 

--- a/src/expidite_rpi/scripts/rpi_installer.sh
+++ b/src/expidite_rpi/scripts/rpi_installer.sh
@@ -652,6 +652,12 @@ create_mount() {
             sudo mount -a
             echo "The expidite mount point has been added to fstab."
         fi
+
+        # Disable swap. We want to protect the SD card by minimising disk writes, and swap memory can require
+        # frequent disk writes.
+        sudo systemctl disable dphys-swapfile
+        sudo systemctl stop dphys-swapfile
+        sudo rm /var/swap 2>/dev/null
     fi
 
 }


### PR DESCRIPTION
We want to protect the SD card by minimising disk writes, and swap memory can require frequent disk writes.

Therefore, disable swap memory from rpi_installer.sh, using the standard commands for doing this on a Raspberry Pi. Also delete any existing swap file to free up space. This runs both on clean install and after the expidite repo is updated on existing installs.

Also lower the threshold for rebooting for high memory usage from 95% to 90%. There is no definitive guidance but there does appear to be consensus that you are likely to see instability and performance degradation above 90%, so that's a better threshold.

