### PR TITLE
DeviceManager cleanup

### DIFF
--- a/src/expidite_rpi/core/device_manager.py
+++ b/src/expidite_rpi/core/device_manager.py
@@ -316,16 +316,19 @@ class DeviceManager:
             utils.run_cmd("sudo nmcli dev disconnect " + self.client_wlan, ignore_errors=True)
             sleep(1)
             utils.run_cmd("sudo nmcli dev connect " + self.client_wlan, ignore_errors=True)
+            sleep(1)
 
         elif self.ping_failure_count_run % retry_frequency == 120:
             logger.info("Toggle wifi radio")
             utils.run_cmd("sudo nmcli radio wifi off", ignore_errors=True)
             sleep(1)
             utils.run_cmd("sudo nmcli radio wifi on", ignore_errors=True)
+            sleep(1)
 
         elif self.ping_failure_count_run % retry_frequency == 180:
             logger.info("Reloading NetworkManager")
             utils.run_cmd("sudo nmcli general reload", ignore_errors=True)
+            sleep(1)
 
         elif self.ping_failure_count_run % retry_frequency == 240:
             # Explicitly connect to bee-ops wifi network
@@ -338,6 +341,7 @@ class DeviceManager:
                         ignore_errors=True,
                     )
                     break
+            sleep(1)
 
     def action_on_ping_ok(self) -> None:
         # Track ping stats for logging purposes

--- a/src/expidite_rpi/core/device_manager.py
+++ b/src/expidite_rpi/core/device_manager.py
@@ -257,27 +257,27 @@ class DeviceManager:
 
     def action_on_ping_fail(self) -> None:
         # Track ping stats for logging purposes
-            self.ping_failure_count_all += 1
-            if self.last_ping_was_ok:
-                self.ping_success_count_run = 0
-                self.ping_failure_count_run = 0
-            self.ping_failure_count_run += 1
-            self.last_ping_was_ok = False
-            logger.info(
-                "Ping failure count run: %s, all (good/bad): %s/%s",
-                str(self.ping_failure_count_run),
-                str(self.ping_success_count_all),
-                str(self.ping_failure_count_all),
-            )
+        self.ping_failure_count_all += 1
+        if self.last_ping_was_ok:
+            self.ping_success_count_run = 0
+            self.ping_failure_count_run = 0
+        self.ping_failure_count_run += 1
+        self.last_ping_was_ok = False
+        logger.info(
+            "Ping failure count run: %s, all (good/bad): %s/%s",
+            str(self.ping_failure_count_run),
+            str(self.ping_success_count_all),
+            str(self.ping_failure_count_all),
+        )
 
-            # Set ping status so that the LEDs reflect this change
-            self.set_ping_status(False)
+        # Set ping status so that the LEDs reflect this change
+        self.set_ping_status(False)
 
-            # Only check Wifi status if ping fails
-            self.check_wifi_status()
+        # Only check Wifi status if ping fails
+        self.check_wifi_status()
 
-            if root_cfg.my_device.attempt_wifi_recovery:
-                self.attempt_wifi_recovery()
+        if root_cfg.my_device.attempt_wifi_recovery:
+            self.attempt_wifi_recovery()
 
     def check_wifi_status(self) -> None:
         # This returns eg "GNX103510:*:95" where * means connected

--- a/src/expidite_rpi/core/device_manager.py
+++ b/src/expidite_rpi/core/device_manager.py
@@ -80,8 +80,6 @@ class DeviceManager:
             self.led_timer.start()
             logger.info("DeviceManager LED timer started")
 
-        return
-    
     def stop(self) -> None:
         """Stop the DeviceManager threads."""
         if self.led_timer is not None:

--- a/src/expidite_rpi/core/device_manager.py
+++ b/src/expidite_rpi/core/device_manager.py
@@ -289,7 +289,7 @@ class DeviceManager:
             self.set_wifi_status(False)
             logger.info("Not connected to a wireless access point")
 
-    ######################################################################################################
+    ##########################################################################################################
     # Attempt to recover WiFi.
     #
     # Possible recovery actions:
@@ -298,12 +298,15 @@ class DeviceManager:
     # - Explicit wifi connect:        nmcli dev wifi connect <SSID> password <password>
     # - Reload NMCLI:                 nlcli general reload
     # - Restart the device:           sudo reboot
-    ######################################################################################################
+    #
+    # Try the first four recovery actions on a 20 minute cycle.
+    # These recovery actions are attempted at 2, 4, 6, 8 minutes respectively into each 20 minute cycle.
+    # If that doesn't recover it, then after the failure count gets to 4 hours reboot the device.
+    ##########################################################################################################
     def attempt_wifi_recovery(self) -> None:
         retry_frequency = 600  # Retry recovery action set every 2s*600=1200s=20mins
 
-        # If the failure count gets to 4 hours then reboot the device
-        # Ping cycle is 2s, so 60*60*2 = 4 hours
+        # Ping cycle is 2s, so 60*60*2 = 4 hours.
         if self.ping_failure_count_run == (60 * 60 * 2):
             logger.error(f"{root_cfg.RAISE_WARN()}Rebooting device due to no internet for >4 hours")
             utils.run_cmd("sudo reboot")

--- a/src/expidite_rpi/core/device_manager.py
+++ b/src/expidite_rpi/core/device_manager.py
@@ -242,106 +242,9 @@ class DeviceManager:
             # -c 1 means ping once, -W 1 means timeout after 1 second
             ping_rc = os.system("ping -c 1 -W 1 8.8.8.8 1>/dev/null")
             if ping_rc != 0:
-                # Track ping stats for logging purposes
-                self.ping_failure_count_all += 1
-                if self.last_ping_was_ok:
-                    self.ping_success_count_run = 0
-                    self.ping_failure_count_run = 0
-                self.ping_failure_count_run += 1
-                self.last_ping_was_ok = False
-                logger.info(
-                    "Ping failure count run: %s, all (good/bad): %s/%s",
-                    str(self.ping_failure_count_run),
-                    str(self.ping_success_count_all),
-                    str(self.ping_failure_count_all),
-                )
-
-                # Set ping status so that the LEDs reflect this change
-                self.set_ping_status(False)
-
-                # Only check Wifi status if ping fails
-                # This returns eg "GNX103510:*:95" where * means connected
-                ESSID = utils.run_cmd("nmcli -g SSID,IN-USE,SIGNAL device wifi | grep '*'", 
-                                      ignore_errors=True)
-                if len(ESSID) > 3:
-                    self.set_wifi_status(True)
-                    logger.info("Wifi is up: " + ESSID)
-                else:
-                    self.set_wifi_status(False)
-                    logger.info("Not connected to a wireless access point")
-
-                #############################################
-                # Recovery actions
-                #
-                # Possible recovery actions:
-                # - Restart the wlan0 interface:  nmcli dev disconnect / connect wlan0
-                # - Toggle radio:                 nmcli radio wifi off / on
-                # - Explicit wifi connect:        nmcli dev wifi connect <SSID> password <password>
-                # - Reload NMCLI:                 nlcli general reload
-                # - Restart the device:           sudo reboot
-                #############################################
-                if root_cfg.my_device.attempt_wifi_recovery:
-                    retry_frequency = 600  # Retry recovery action set every 2s*600=1200s=20mins
-
-                    # If the failure count gets to 4 hours then reboot the device
-                    # Ping cycle is 2s, so 60*60*2 = 4 hours
-                    if self.ping_failure_count_run == (60 * 60 * 2):
-                        logger.error(f"{root_cfg.RAISE_WARN()}Rebooting device "
-                                     f"due to no internet for >4 hours")
-                        utils.run_cmd("sudo reboot")
-
-                    elif self.ping_failure_count_run % retry_frequency == 60:
-                        logger.info("Restarting client wifi interface")
-                        utils.run_cmd("sudo nmcli dev disconnect " + self.client_wlan, ignore_errors=True)
-                        sleep(1)
-                        utils.run_cmd("sudo nmcli dev connect " + self.client_wlan, ignore_errors=True)
-
-                    elif self.ping_failure_count_run % retry_frequency == 120:
-                        logger.info("Toggle wifi radio")
-                        utils.run_cmd("sudo nmcli radio wifi off", ignore_errors=True)
-                        sleep(1)
-                        utils.run_cmd("sudo nmcli radio wifi on", ignore_errors=True)
-
-                    elif self.ping_failure_count_run % retry_frequency == 180:
-                        logger.info("Reloading NetworkManager")
-                        utils.run_cmd("sudo nmcli general reload", ignore_errors=True)
-
-                    elif self.ping_failure_count_run % retry_frequency == 240:
-                        # Explicitly connect to bee-ops wifi network
-                        logger.info("Explicitly connecting to wifi network")
-                        for client in self.wifi_clients:
-                            if client.ssid is not None and client.pw is not None:
-                                logger.info(f"Connecting to {client.ssid}")
-                                utils.run_cmd(
-                                    f"sudo nmcli dev wifi connect {client.ssid} password {client.pw}",
-                                    ignore_errors=True,
-                                )
-                                break
-
-                    #############################################
-                    # End of recovery actions
-                    #############################################
-
-            # Ping was successful
+                self.action_on_ping_fail()
             else:
-                # Track ping stats for logging purposes
-                self.ping_success_count_all += 1
-                if not self.last_ping_was_ok:
-                    self.ping_failure_count_run = 0
-                    self.ping_success_count_run = 0
-                self.ping_success_count_run += 1
-                if self.ping_success_count_run % 30 == 0:
-                    logger.info(
-                        "Ping successful count run: %s, all (good/bad): %s/%s",
-                        str(self.ping_success_count_run),
-                        str(self.ping_success_count_all),
-                        str(self.ping_failure_count_all),
-                    )
-
-                # Set ping status so that the LEDs reflect this change
-                self.set_ping_status(True)
-
-                self.last_ping_was_ok = True
+                self.action_on_ping_ok()
 
             # Log useful info and status periodically
             if self.log_counter % self.wifi_log_frequency == 0:
@@ -351,3 +254,104 @@ class DeviceManager:
         except Exception as e:
             logger.error(f"{root_cfg.RAISE_WARN()}Wifi timer callback threw an exception: " + str(e), 
                         exc_info=True)
+
+    def action_on_ping_fail(self) -> None:
+        # Track ping stats for logging purposes
+            self.ping_failure_count_all += 1
+            if self.last_ping_was_ok:
+                self.ping_success_count_run = 0
+                self.ping_failure_count_run = 0
+            self.ping_failure_count_run += 1
+            self.last_ping_was_ok = False
+            logger.info(
+                "Ping failure count run: %s, all (good/bad): %s/%s",
+                str(self.ping_failure_count_run),
+                str(self.ping_success_count_all),
+                str(self.ping_failure_count_all),
+            )
+
+            # Set ping status so that the LEDs reflect this change
+            self.set_ping_status(False)
+
+            # Only check Wifi status if ping fails
+            self.check_wifi_status()
+
+            if root_cfg.my_device.attempt_wifi_recovery:
+                self.attempt_wifi_recovery()
+
+    def check_wifi_status(self) -> None:
+        # This returns eg "GNX103510:*:95" where * means connected
+        essid = utils.run_cmd("nmcli -g SSID,IN-USE,SIGNAL device wifi | grep '*'", ignore_errors=True)
+        if len(essid) > 3:
+            self.set_wifi_status(True)
+            logger.info(f"Wifi is up: {essid}")
+        else:
+            self.set_wifi_status(False)
+            logger.info("Not connected to a wireless access point")
+
+    ######################################################################################################
+    # Attempt to recover WiFi.
+    #
+    # Possible recovery actions:
+    # - Restart the wlan0 interface:  nmcli dev disconnect / connect wlan0
+    # - Toggle radio:                 nmcli radio wifi off / on
+    # - Explicit wifi connect:        nmcli dev wifi connect <SSID> password <password>
+    # - Reload NMCLI:                 nlcli general reload
+    # - Restart the device:           sudo reboot
+    ######################################################################################################
+    def attempt_wifi_recovery(self) -> None:
+        retry_frequency = 600  # Retry recovery action set every 2s*600=1200s=20mins
+
+        # If the failure count gets to 4 hours then reboot the device
+        # Ping cycle is 2s, so 60*60*2 = 4 hours
+        if self.ping_failure_count_run == (60 * 60 * 2):
+            logger.error(f"{root_cfg.RAISE_WARN()}Rebooting device due to no internet for >4 hours")
+            utils.run_cmd("sudo reboot")
+
+        elif self.ping_failure_count_run % retry_frequency == 60:
+            logger.info("Restarting client wifi interface")
+            utils.run_cmd("sudo nmcli dev disconnect " + self.client_wlan, ignore_errors=True)
+            sleep(1)
+            utils.run_cmd("sudo nmcli dev connect " + self.client_wlan, ignore_errors=True)
+
+        elif self.ping_failure_count_run % retry_frequency == 120:
+            logger.info("Toggle wifi radio")
+            utils.run_cmd("sudo nmcli radio wifi off", ignore_errors=True)
+            sleep(1)
+            utils.run_cmd("sudo nmcli radio wifi on", ignore_errors=True)
+
+        elif self.ping_failure_count_run % retry_frequency == 180:
+            logger.info("Reloading NetworkManager")
+            utils.run_cmd("sudo nmcli general reload", ignore_errors=True)
+
+        elif self.ping_failure_count_run % retry_frequency == 240:
+            # Explicitly connect to bee-ops wifi network
+            logger.info("Explicitly connecting to wifi network")
+            for client in self.wifi_clients:
+                if client.ssid is not None and client.pw is not None:
+                    logger.info(f"Connecting to {client.ssid}")
+                    utils.run_cmd(
+                        f"sudo nmcli dev wifi connect {client.ssid} password {client.pw}",
+                        ignore_errors=True,
+                    )
+                    break
+
+    def action_on_ping_ok(self) -> None:
+        # Track ping stats for logging purposes
+        self.ping_success_count_all += 1
+        if not self.last_ping_was_ok:
+            self.ping_failure_count_run = 0
+            self.ping_success_count_run = 0
+        self.ping_success_count_run += 1
+        if self.ping_success_count_run % 30 == 0:
+            logger.info(
+                "Ping successful count run: %s, all (good/bad): %s/%s",
+                str(self.ping_success_count_run),
+                str(self.ping_success_count_all),
+                str(self.ping_failure_count_all),
+            )
+
+        # Set ping status so that the LEDs reflect this change
+        self.set_ping_status(True)
+
+        self.last_ping_was_ok = True

--- a/src/expidite_rpi/core/stats_tracker.py
+++ b/src/expidite_rpi/core/stats_tracker.py
@@ -67,7 +67,7 @@ class StatTracker(Sensor):
         self.dpworkers = dpworkers
 
     def run(self) -> None:
-        """Main loop for the DeviceHealth sensor.
+        """Main loop for the StatTracker.
         This method is called when the thread is started.
         It runs in a loop, logging health data and warnings at regular intervals.
         """


### PR DESCRIPTION
Some minor refactoring for maintainability/readability. This paves the way for making some diagnostics enhancements.

1. Delete unnecessary return.
2. Fix comment typo
3. Restructure DeviceManager into smaller functions

    wifi_timer_callback was quite big, and essentially handled two things, so for readability/maintainability, split it into:
    - action_on_ping_fail()
    - action_on_ping_ok()

    Then further split out
    - attempt_wifi_recovery()
    - check_wifi_status()

    There is no change of logic here.

4. Clarify comments explaining how recovery works.

5. Sleep after recovery actions
    Without these, the next call to wifi_timer_callback immediately after a recovery action is sometimes observed to fail the ping because the recovery hasn't quite completed. This is probably benign as we'll just try again on the next wifi_timer_callback, but this makes the logs cleaner by not logging an extra failure.
