### PR TITLE
Fix exception in EdgeOrchestrator._safe_call_create_method()

### DIFF
--- a/src/expidite_rpi/core/edge_orchestrator.py
+++ b/src/expidite_rpi/core/edge_orchestrator.py
@@ -172,7 +172,7 @@ class EdgeOrchestrator:
 
         if not isinstance(dp_trees, list):
             logger.error(f"{root_cfg.RAISE_WARN()}create_method must return a list; "
-                         f"created {dp_trees.__type__}")
+                         f"created {type(dp_trees)}")
             raise ValueError("create_method must return a list of DPtree objects")
         
         return dp_trees


### PR DESCRIPTION
type() is the correct way to get an object's type, not __type__ which will throw an exception.

Only possible to hit on a misconfigured system where a custom create_method does not return a list.