### PR TITLE
Add DiagnosticsBundle

### DIFF
--- a/src/expidite_rpi/core/cloud_connector.py
+++ b/src/expidite_rpi/core/cloud_connector.py
@@ -886,7 +886,7 @@ class AsyncCloudConnector(CloudConnector):
             for i, file in enumerate(src_files):
                 # Move the files to the tmp_dir
                 tmp_file = tmp_dir / file.name
-                file.rename(tmp_file)
+                shutil.move(file, tmp_file)
                 src_files[i] = tmp_file
 
         if src_files:

--- a/src/expidite_rpi/core/configuration.py
+++ b/src/expidite_rpi/core/configuration.py
@@ -104,6 +104,7 @@ if running_on_windows:
     # We use a time string in the root_working_dir to avoid clashes when running multiple instances
     # of RpiCore on the same machine
     ROOT_WORKING_DIR: Path = Path(tempfile.gettempdir()) / "expidite" / api.utc_to_fname_str()
+    DIAGS_DIR: Path = HOME_DIR / "expidite-diags"
     assert HOME_DIR is not None, f"No 'code' directory found in path {Path.cwd()}"
 
 elif running_on_rpi:
@@ -113,6 +114,7 @@ elif running_on_rpi:
     SC_CODE_DIR = CODE_DIR / "expidite"
     CFG_DIR = HOME_DIR / ".expidite"  # In the base user directory on the RPi
     ROOT_WORKING_DIR = Path("/expidite")
+    DIAGS_DIR = Path("/expidite-diags")
     utils_clean.create_root_working_dir(ROOT_WORKING_DIR)
 
 elif running_on_linux:
@@ -122,6 +124,7 @@ elif running_on_linux:
     SC_CODE_DIR = Path("/app")
     CFG_DIR = Path("/run/secrets")
     ROOT_WORKING_DIR = Path("/expidite")
+    DIAGS_DIR = Path("/expidite-diags") # Deliberately separate, so that it survives reboot.
     utils_clean.create_root_working_dir(ROOT_WORKING_DIR)
 else:
     raise Exception("Unknown platform: " + platform.platform())
@@ -151,6 +154,7 @@ dirs = [
     TEST_DIR,
     FLAGS_DIR,
     TMP_FLAGS_DIR,
+    DIAGS_DIR,
     EDGE_PROCESSING_DIR,
     EDGE_STAGING_DIR,
     EDGE_UPLOAD_DIR,

--- a/src/expidite_rpi/core/device_config_objects.py
+++ b/src/expidite_rpi/core/device_config_objects.py
@@ -91,6 +91,9 @@ class DeviceCfg(Configuration):
     # Cloud storage container for system test results
     cc_for_system_test: str = "expidite-system-test"
 
+    # Cloud storage container for diagnostics bundles.
+    cc_for_diagnostics_bundles: str = "expidite-diags"
+
     # Frequency of sending device health heart beat
     heart_beat_frequency: int = 60 * 10
 

--- a/src/expidite_rpi/core/diagnostics_bundle.py
+++ b/src/expidite_rpi/core/diagnostics_bundle.py
@@ -1,0 +1,165 @@
+import gzip
+import os
+import subprocess
+from pathlib import Path
+
+from expidite_rpi.core import api, file_naming
+from expidite_rpi.core import configuration as root_cfg
+from expidite_rpi.core.cloud_connector import CloudConnector
+
+logger = root_cfg.setup_logger("expidite")
+
+DIAGNOSTIC_COMMANDS = [
+    # System and time.
+    ("System date and time", "date"),
+    ("System uptime", "uptime"),
+    ("Kernel information", "uname -a"),
+    # Network status.
+    ("Network Manager status", "nmcli general status"),
+    ("Network interface status", "nmcli device status"),
+    ("Configured connections", "nmcli connection show"),
+    ("Wi-Fi hardware state", "nmcli radio"),
+    ("All network interfaces", "ip a"),
+    ("Routing table", "ip r"),
+    ("ARP cache", "arp -a"),
+    ("Active connections", "ss -tulnpa"),
+    ("Wi-Fi status (if on older systems)", "iwconfig"),
+    ("DNS resolution config", "cat /etc/resolv.conf"),
+    # Connectivity checks.
+    ("Ping Google DNS (8.8.8.8)", "ping -c 4 8.8.8.8"),
+    # Power and hardware Status
+    ("CPU Temperature", "vcgencmd measure_temp"),
+    ("Voltage/throttling status", "vcgencmd get_throttled"),
+    ("Current CPU/GPU clock speeds", "vcgencmd measure_clock arm; vcgencmd measure_clock core"),
+    # Resource usage.
+    ("Disk usage", "df -h"),
+    ("Memory usage", "free -h"),
+    ("Top processes snapshot", "top -bn1 | head -n 20"),  # Only show the first 20 lines
+    ("Last 50 kernel messages", "dmesg | tail -n 50"),
+    # Logs.
+    ("Recent logs", "journalctl -n 1000 --no-pager"),
+    # Expidite status
+    ("Expidite files", f"ls -lhR {root_cfg.ROOT_WORKING_DIR}"),
+    ("Expidite config files", f"ls -lhR {root_cfg.CFG_DIR}"),
+    ("EXPIDITE_IS_RUNNING_FLAG", f"cat {root_cfg.EXPIDITE_IS_RUNNING_FLAG}"),
+    ("LED_STATUS_FILE", f"cat {root_cfg.LED_STATUS_FILE}"),
+]
+
+##############################################################################################################
+# The sole purpose of this class is to write a diagnostics bundle to disk, containing as much information as
+# possible to help understand how/why the device got into a bad state, such as lost connectivity or out of
+# memory. Any code which deliberately reboots the device should first generate a diagnostics bundle.
+#
+# The diagnostics bundle is expected to be retrieved either:
+# - manually by copying off the SD card, if the device never recovers and has to be physically retrieved, or
+# - if connectivity recovers, it will be uploaded to cloud storage.
+#
+# There is a small amount of duplication here with DeviceHealth, RpiCore and bcli. This is hard to avoid while
+# keeping this class self contained.
+##############################################################################################################
+class DiagnosticsBundle:
+    @staticmethod
+    def collect(reason: str):
+        """Collects and saves a diagnostics bundle to a time-stamped file."""
+
+        if not root_cfg.running_on_rpi:
+            return
+
+        # Limit disk usage by limiting the number of files. If we have connectivity they should be getting
+        # uploaded to cloud storage and then deleted. If not, then there isn't much value in keep storing for
+        # files.
+        if len(os.listdir(root_cfg.DIAGS_DIR)) > 10:
+            logger.info("Skip diagnostic collection because too many existing files")
+            return
+
+        log_filename = file_naming.get_diags_filename()
+
+        logger.info(f"Starting diagnostic collection to {log_filename}")
+
+        def write_bar():
+            f.write("=" * 150 + "\n")
+
+        with gzip.open(log_filename, "wt") as f:
+            write_bar()
+            f.write(f"Report generated: {api.utc_now()}\n")
+            f.write(f"Reason:           {reason}\n")
+            write_bar()
+
+            for title, command in DIAGNOSTIC_COMMANDS:
+                f.write(f"\n### {title} ({command}) ###\n")
+                stdout, stderr, returncode = DiagnosticsBundle._run_cmd(command)
+                f.write(f"Exit code: {returncode}\n")
+
+                if stdout:
+                    f.write("--- STDOUT ---\n")
+                    f.write(stdout + "\n")
+
+                if stderr:
+                    f.write("--- STDERR ---\n")
+                    f.write(stderr + "\n")
+
+                f.write("\n")
+                write_bar()
+
+            expidite_version, user_code_version = root_cfg.get_version_info()
+            f.write(f"\nExpidite version: {expidite_version}\n")
+            f.write(f"User code version: {user_code_version}\n")
+            f.write("\nExpidite system configuration:\n")
+            for key, value in root_cfg.system_cfg.model_dump().items():
+                f.write(f"    {key}: {value}\n")
+
+            f.write(f"\nExpidite device configuration:\n{root_cfg.my_device.display()}")
+            if root_cfg.keys:
+                f.write(f"\nStorage account: {root_cfg.keys.get_storage_account()}\n")
+
+            # Import here to avoid circular dependency.
+            from expidite_rpi.core.device_health import DeviceHealth
+            health = DeviceHealth().get_health(check_memory_usage = False)
+            if health:
+                f.write("\nDevice health\n")
+                for key, value in health.items():
+                    f.write(f"    {key}: {value}\n")
+
+            f.write("\n")
+            write_bar()
+
+        logger.info(f"Completed diagnostic collection to {log_filename}")
+
+    @staticmethod
+    def _run_cmd(command) -> tuple[str, str, int]:
+        """Executes a shell command and returns its output and any errors."""
+        try:
+            result = subprocess.run(
+                command,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=15, # Timeout in seconds, in case any command hangs.
+            )
+            return result.stdout.strip(), result.stderr.strip(), result.returncode
+        except subprocess.TimeoutExpired:
+            return "COMMAND TIMEOUT: Command exceeded 15 seconds.", "", 1
+        except Exception as e:
+            return f"EXECUTION ERROR: {e}", "", 1
+
+    @staticmethod
+    def upload():
+        """Upload existing diagnostics bundles, if any, from disk to cloud storage."""
+        try:
+            for filename in os.listdir(root_cfg.DIAGS_DIR):
+                if filename.endswith(".gz"):
+                    full_path = os.path.join(root_cfg.DIAGS_DIR, filename)
+
+                    if os.path.isfile(full_path):
+                        logger.info(f"Upload diagnostic bundle {filename}")
+                        cc = CloudConnector.get_instance(root_cfg.CLOUD_TYPE)
+                        cc.upload_to_container(
+                            root_cfg.my_device.cc_for_diagnostics_bundles,
+                            [Path(full_path)],
+                            delete_src=True,
+                            storage_tier=api.StorageTier.COOL,
+                        )
+        except FileNotFoundError:
+            print("Error: Directory not found")
+        except PermissionError:
+            print("Error: Permission denied")

--- a/src/expidite_rpi/core/file_naming.py
+++ b/src/expidite_rpi/core/file_naming.py
@@ -323,6 +323,9 @@ def get_system_test_filename(st_type: str) -> Path:
     t = api.utc_now()
     return root_cfg.EDGE_UPLOAD_DIR / f"V3_{root_cfg.my_device_id}_{st_type}_{t.strftime('%Y%m%d')}.csv"
 
+def get_diags_filename() -> Path:
+    """Generate a filename for a diags bundle file in the diags directory."""
+    return root_cfg.DIAGS_DIR / f"V3_DIAGS_{root_cfg.my_device_id}_{api.utc_to_fname_str()}.log.gz"
 
 def get_review_mode_filename(
     data_id: str,

--- a/src/expidite_rpi/scripts/rpi_installer.sh
+++ b/src/expidite_rpi/scripts/rpi_installer.sh
@@ -653,6 +653,12 @@ create_mount() {
             echo "The expidite mount point has been added to fstab."
         fi
 
+        # The diagnostics mountpoint is always on disk, so that it survives reboot. This is OK because its use is very
+        # limited - only for when diagnostics are saved when rebooting as a recovery action.
+        diags_mountpoint="/expidite-diags"
+        sudo mkdir -p $diags_mountpoint
+        sudo chown -R $USER:$USER $diags_mountpoint
+
         # Disable swap. We want to protect the SD card by minimising disk writes, and swap memory can require
         # frequent disk writes.
         sudo swapoff -a


### PR DESCRIPTION
For cases where we reboot the device to recover from severe failure modes, such as non-recoverable loss of connectivity, and high memory usage. We want diagnostics to help understand the cause of failure. Existing diagnostics are either:
- written to RAM disk, so are lost on reboot, or
- uploaded to cloud storage periodically, but have limited content and may not be up to date enough.

Before rebooting the device, we now generate a new diagnostics bundle.
- This is a compressed file containing the Expidite configuration and the output of several Linux commands.
- Write it to disk (not the RAM disk) so that it survives reboot.

And we now run a timer to periodically check for the presence of diagnostics bundles and upload them to a new container in cloud storage.

DiagnosticsBundle is a new class with two key public methods:
- collect: execute several Linux commands and get Expidite configuration, writing all to a compressed file. Limit disk usage by limiting number of files.
- upload: upload all files from disk to cloud storage, deleting after upload.

Other changes of note:
- rpi_installer.sh: create new directory on disk for diagnostics bundles.
- CloudConnector: replace file.rename with shutil.move because file.rename does not work across file systems, so cannot move a file from real disk to RAM disk. shutil.move first tries file.rename (so no change to existing uses) then falls back to a copy and delete.
- DeviceHealth: collect diagnostics if memory use exceeds 90%, before rebooting.
- DeviceManager: collect diagnostics if no connectivity, before rebooting. Run a new timer to periodically upload any diagnostics bundles from disk to cloud storage.