### PR TITLE
Fix: UnboundLocalError in _get_csv_as_df()

### DIFF
--- a/src/expidite_rpi/core/dp_worker_thread.py
+++ b/src/expidite_rpi/core/dp_worker_thread.py
@@ -216,5 +216,6 @@ class DPworker(Thread):
             df = pd.concat(df_list, ignore_index=True)
             logger.debug(f"Loaded {len(df)} rows from CSV files for {data_id}")
         else:
+            df = None
             logger.debug(f"No CSV files found for {data_id}")
         return df


### PR DESCRIPTION
Fix: UnboundLocalError: cannot access local variable 'df' where it is not associated with a value.

This exception is hit on `return df` after passing through the `else` branch because `df` hasn't been set to anything.